### PR TITLE
Fix `GET` request not working

### DIFF
--- a/src/elastic-client.ts
+++ b/src/elastic-client.ts
@@ -178,7 +178,7 @@ export class ElasticClient {
   }
 
   async get<T>(params: GetRequest): Promise<Response<GetResponse<T>>> {
-    let url = `/${params.index}${params.id}`
+    let url = `/${params.index}/_doc/${params.id}`
 
     const queryParams = queryParametersGenerator(
       {


### PR DESCRIPTION
There was a bug in the url for GET request. Based on the [API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html) it should be `<index>/_doc/<_id>`, but was `<index><_id>`.